### PR TITLE
docs: Use a clear name for the Polarion template

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Update Template Properties
       run: |
-        sed -i "1s|.*|name=DBS MBSE Template Version ${{  github.ref_name }}|" template/template.properties
-        sed -i "2s|.*|description=Standard MBSE Template Project for Deutsche Bahn (DBS), $(date '+%d.%m.%Y')|" template/template.properties
+        sed -i "1s|.*|name=Capella2Polarion Template Version ${{  github.ref_name }}|" template/template.properties
+        sed -i "2s|.*|description=Template for Capella2Polarion Sync-Projects in Polarion, $(date '+%d.%m.%Y')|" template/template.properties
     - name: Zip Template Folder
       run: |
         mkdir ${{ vars.TEMPLATE_FILENAME }} && cp -r template/. ${{ vars.TEMPLATE_FILENAME }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0 -->
 
-# Polarion Project Template
+# Capella2Polarion Project Template
 A Polarion project template with icons and predefined work item types, work
 item type links for Capella model objects.
 

--- a/template/template.properties
+++ b/template/template.properties
@@ -1,3 +1,3 @@
-name=DBS MBSE Template Version 1.0
-description=Standard MBSE Template Project for Deutsche Bahn (DBS), 21.07.2023
+name=Capella2Polarion Template Version X.X
+description=Template for Capella2Polarion Sync-Projects in Polarion, %d.%m.%Y
 process=.polarion/tracker/fields/workitem-type-enum.xml


### PR DESCRIPTION
Before, it was not clear which template to select in the list of templates. The template name or description didn't contain any reference to Capella or Capella2Polarion.

In addition, it had a reference to "Deutsche Bahn", but the template can of cause also be used outside of Deutsche Bahn.

I've also updated the `TEMPLATE_FILENAME` variable to `Capella2Polarion_template`. Please note that when uploading a version with the name filename, the old template is not overwritten. 