### PR TITLE
Slim-global-config

### DIFF
--- a/global/fields/_C2P_actor-custom-fields.xml
+++ b/global/fields/_C2P_actor-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_capability-custom-fields.xml
+++ b/global/fields/_C2P_capability-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_class-custom-fields.xml
+++ b/global/fields/_C2P_class-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_communicationMean-custom-fields.xml
+++ b/global/fields/_C2P_communicationMean-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_component-custom-fields.xml
+++ b/global/fields/_C2P_component-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_componentExchange-custom-fields.xml
+++ b/global/fields/_C2P_componentExchange-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_constraint-custom-fields.xml
+++ b/global/fields/_C2P_constraint-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_exchangeItem-custom-fields.xml
+++ b/global/fields/_C2P_exchangeItem-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_function-custom-fields.xml
+++ b/global/fields/_C2P_function-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_functionalChain-custom-fields.xml
+++ b/global/fields/_C2P_functionalChain-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_functionalExchange-custom-fields.xml
+++ b/global/fields/_C2P_functionalExchange-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_layer-enum.xml
+++ b/global/fields/_C2P_layer-enum.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+SPDX-License-Identifier: Apache-2.0 -->
+<enumeration>
+  <option id="common" name="Common" sortOrder="0"></option>
+  <option id="oa" name="Operational Architecture" sortOrder="1"></option>
+  <option id="sa" name="System Analysis" sortOrder="2"></option>
+  <option id="la" name="Logical Architecture" sortOrder="3"></option>
+  <option id="pa" name="Physical Architecture" sortOrder="4"></option>
+</enumeration>

--- a/global/fields/_C2P_operationalActivity-custom-fields.xml
+++ b/global/fields/_C2P_operationalActivity-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_operationalEntity-custom-fields.xml
+++ b/global/fields/_C2P_operationalEntity-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_operationalInteraction-custom-fields.xml
+++ b/global/fields/_C2P_operationalInteraction-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_physicalLink-custom-fields.xml
+++ b/global/fields/_C2P_physicalLink-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_physicalPath-custom-fields.xml
+++ b/global/fields/_C2P_physicalPath-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_scenario-custom-fields.xml
+++ b/global/fields/_C2P_scenario-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_state-custom-fields.xml
+++ b/global/fields/_C2P_state-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/_C2P_stateMachine-custom-fields.xml
+++ b/global/fields/_C2P_stateMachine-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/global/fields/diagram-custom-fields.xml
+++ b/global/fields/diagram-custom-fields.xml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 -->
   <field id="checksum" name="Checksum" type="string" description="A checksum-hash of the work item for efficient comparison for the SET Toolchain."/>
   <field id="parent" name="Parent" type="text/html" description="Grouped links for parent."/>
   <field id="parent_reverse" name="Children" type="text/html" description="Grouped links backlinks for parent."/>
-  <field id="layer" name="Layer" type="string" description="The layer of the work item."/>
+  <field id="layer" name="Layer" type="enum:_C2P_layer" description="The layer of the work item."/>
   <field id="assumption" name="Assumption" type="text/html" description="Requirement text from a Requirement of type Assumption."/>
   <field id="availability" name="Availability" type="text/html" description="Requirement text from a Requirement of type Availability."/>
   <field id="computation" name="Computation" type="text/html" description="Requirement text from a Requirement of type Computation."/>

--- a/scripts/generate_custom_fields.py
+++ b/scripts/generate_custom_fields.py
@@ -36,7 +36,7 @@ FIELDS: dict[str, t.Any] = {
         "layer": {
             "name": "Layer",
             "description": "The layer of the work item.",
-            "type": "string",
+            "type": "enum:_C2P_layer",
         },
     },
     "Requirement Fields": {


### PR DESCRIPTION
This PR reduces the work item types `Capability`, `Component`, `Actor`, `Function`, `FunctionalExchange` and `ComponentExchange`. With this we are able to reduce from 18 to 6 work item types. Could be even more because we still keep `Activity` (Function) and `Entity` (Component) from the oa level. Also the form layout configurations are generated from the function in the script.